### PR TITLE
OPNA adpcm minimap表示不具合修正

### DIFF
--- a/c86ctl/src/chip/opna.h
+++ b/c86ctl/src/chip/opna.h
@@ -50,6 +50,7 @@ public:
 		memset(map,0,ramsize);
 		memset(wav,0,ramsize*2*2);
 		memset(minimap,0,minimapsize);
+		memset(reg, 0, 256);
 	}
 	void update(){
 		if(keyOnLevel) keyOnLevel--;
@@ -88,7 +89,8 @@ protected:
 	
 	UCHAR control1;
 	UCHAR control2;
-	
+	UCHAR reg[256];
+
 	bool left;
 	bool right;
 	bool sw;


### PR DESCRIPTION
1bitモード対応。
アドレス計算間違い修正。
deltaN更新時にlevel値を破壊していた不具合修正。
演奏済みADPCMメモリ上書き時にminimap表示をクリアするように変更。